### PR TITLE
Migrate publishing to Central Portal (vanniktech + auto-release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Deployment
 on:
   push:
     branches:
-      - master
+      - develop  # publishes an overwritable -SNAPSHOT
+      - master   # auto-releases the permanent version to Maven Central
 
 jobs:
   deploy:
@@ -15,12 +16,12 @@ jobs:
         uses: Oztechan/Global/actions/setup-gradle-repo@8610938e630b3ed86127765237fe3647b9fabd4f
 
       - name: Publish
-        run: ./gradlew publish
+        run: ./gradlew publishToMavenCentral --no-configuration-cache
         env:
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-          GPG_KEY: ${{ secrets.GPG_KEY }}
-          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSWORD }}
 
       - name: Notify slack success
         if: success()

--- a/ScopeMob.gradle.kts
+++ b/ScopeMob.gradle.kts
@@ -2,15 +2,13 @@
  * Copyright (c) 2020 Mustafa Ozhan. All rights reserved.
  */
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import java.io.IOException
-import java.util.Properties
 
 plugins {
     libs.plugins.apply {
-        alias(libs.plugins.kotlinMultiplatform).apply(false)
-        alias(libs.plugins.kover)
+        alias(kotlinMultiplatform).apply(false)
+        alias(mavenPublish).apply(false)
+        alias(kover)
     }
-    `maven-publish`
 }
 
 allprojects {
@@ -20,74 +18,13 @@ allprojects {
         rootProject.dependencies.add("kover", project(path))
     }
 
-    Library.apply {
+    // Group + POM metadata + Central Portal config come from gradle.properties (read by
+    // com.vanniktech.maven.publish). Only the version is dynamic (git commit count).
+    version = ProjectSettings.getVersionName(project)
 
-        group = GROUP
-        version = ProjectSettings.getVersionName(project)
-
-        repositories {
-            google()
-            mavenCentral()
-        }
-
-        val emptyJavadocJar = tasks.register<Jar>("emptyJavadocJar") {
-            description = "Generates an empty Javadoc JAR for publishing."
-            archiveClassifier.set("javadoc")
-        }
-
-        afterEvaluate {
-            extensions.findByType<PublishingExtension>()?.apply {
-                repositories {
-                    maven {
-                        url = uri(if (isReleaseBuild) RELEASE_URL else SNAPSHOT_URL)
-                        credentials {
-                            username = getSecret("MAVEN_USERNAME")
-                            password = getSecret("MAVEN_PASSWORD")
-                        }
-                    }
-                }
-
-                publications.withType<MavenPublication>().configureEach {
-                    artifact(emptyJavadocJar.get())
-
-                    pom {
-                        name.set(NAME)
-                        description.set(DESCRIPTION)
-                        url.set(URL)
-
-                        licenses {
-                            license {
-                                name.set(LICENSE_NAME)
-                                url.set(LICENSE_URL)
-                                distribution.set(LICENSE_DISTRIBUTION)
-                            }
-                        }
-                        developers {
-                            developer {
-                                id.set(DEVELOPER_ID)
-                                name.set(DEVELOPER_NAME)
-                                email.set(DEVELOPER_EMAIL)
-                            }
-                        }
-                        scm { url.set(URL) }
-                    }
-                }
-            }
-
-            extensions.findByType<PublishingExtension>()?.let { publishing ->
-                val key = getSecret("GPG_KEY").replace("\\n", "\n")
-                val password = getSecret("GPG_PASSWORD")
-
-                extensions.findByType<SigningExtension>()?.apply {
-                    useInMemoryPgpKeys(key, password)
-                    sign(publishing.publications)
-                }
-            }
-
-            tasks.withType<Sign>().configureEach {
-                onlyIf { isReleaseBuild }
-            }
-        }
+    repositories {
+        google()
+        mavenCentral()
     }
 
     tasks.withType<KotlinCompile> {
@@ -95,40 +32,4 @@ allprojects {
             allWarningsAsErrors = true
         }
     }
-}
-
-val isReleaseBuild: Boolean
-    get() = System.getenv("GPG_KEY") != null
-
-fun getSecret(
-    key: String,
-    default: String = "secret" // these values can not be public
-): String = System.getenv(key).let {
-    if (it.isNullOrEmpty()) {
-        getSecretProperties()?.get(key)?.toString() ?: default
-    } else {
-        it
-    }
-}
-
-fun getSecretProperties() = try {
-    Properties().apply { load(file("key.properties").inputStream()) }
-} catch (e: IOException) {
-    logger.debug(e.message, e)
-    null
-}
-
-object Library {
-    const val GROUP = "com.github.submob"
-    const val URL = "https://github.com/SubMob/ScopeMob"
-    const val NAME = "ScopeMob"
-    const val DESCRIPTION = "Set of useful scope and higher-order functions"
-    const val DEVELOPER_NAME = "Mustafa Ozhan"
-    const val DEVELOPER_ID = "mustafaozhan"
-    const val DEVELOPER_EMAIL = "mr.mustafa.ozhan@gmail.com"
-    const val LICENSE_NAME = "The Apache Software License, Version 2.0"
-    const val LICENSE_URL = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-    const val LICENSE_DISTRIBUTION = "repo"
-    const val RELEASE_URL = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
-    const val SNAPSHOT_URL = "https://s01.oss.sonatype.org/content/repositories/snapshots"
 }

--- a/buildSrc/src/main/kotlin/ProjectSettings.kt
+++ b/buildSrc/src/main/kotlin/ProjectSettings.kt
@@ -10,9 +10,24 @@ object ProjectSettings {
     // git rev-list --first-parent --count master +1
     private const val VERSION_DIF = 95
 
-    fun getVersionName(
-        project: Project
-    ) = "$MAYOR_VERSION.$MINOR_VERSION.${gitCommitCount(project).toInt() - VERSION_DIF}"
+    fun getVersionName(project: Project): String = if (isMaster(project)) {
+        // Permanent, pinnable release: x.y.<commit-count>.
+        "$MAYOR_VERSION.$MINOR_VERSION.${gitCommitCount(project).toInt() - VERSION_DIF}"
+    } else {
+        // Stable moving snapshot ("latest develop") — consumers pin x.y-SNAPSHOT and always get newest.
+        "$MAYOR_VERSION.$MINOR_VERSION-SNAPSHOT"
+    }
+
+    private fun isMaster(project: Project): Boolean = currentBranch(project) == "master"
+
+    private fun currentBranch(project: Project): String {
+        // In GitHub Actions the checked-out branch is exposed as GITHUB_REF_NAME; fall back to git locally.
+        val ciBranch = project.providers.environmentVariable("GITHUB_REF_NAME").orNull
+        if (!ciBranch.isNullOrBlank()) return ciBranch
+        return project.providers.exec {
+            commandLine("git rev-parse --abbrev-ref HEAD".split(" "))
+        }.standardOutput.asText.get().trim()
+    }
 
     private fun gitCommitCount(project: Project): String = project.providers.exec {
         commandLine("git rev-list --first-parent --count HEAD".split(" "))

--- a/buildSrc/src/main/kotlin/ProjectSettings.kt
+++ b/buildSrc/src/main/kotlin/ProjectSettings.kt
@@ -4,11 +4,11 @@
 import org.gradle.api.Project
 
 object ProjectSettings {
-    private const val MAYOR_VERSION = 2
-    private const val MINOR_VERSION = 1
+    private const val MAYOR_VERSION = 3
+    private const val MINOR_VERSION = 0
 
-    // git rev-list --first-parent --count master +1
-    private const val VERSION_DIF = 95
+    // git rev-list --first-parent --count master (recalibrated at the 3.0 major bump)
+    private const val VERSION_DIF = 102
 
     fun getVersionName(project: Project): String = if (isMaster(project)) {
         // Permanent, pinnable release: x.y.<commit-count>.

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,22 @@ kotlin.incremental=true
 kotlin.incremental.native=true
 # KMP
 kotlin.incremental.multiplatform=true
+# Maven Central publishing (Central Portal) via com.vanniktech.maven.publish
+GROUP=com.github.submob
+POM_ARTIFACT_ID=scopemob
+POM_NAME=ScopeMob
+POM_DESCRIPTION=Set of useful scope and higher-order functions
+POM_INCEPTION_YEAR=2020
+POM_URL=https://github.com/SubMob/ScopeMob
+POM_LICENSE_NAME=The Apache Software License, Version 2.0
+POM_LICENSE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENSE_DIST=repo
+POM_DEVELOPER_ID=mustafaozhan
+POM_DEVELOPER_NAME=Mustafa Ozhan
+POM_DEVELOPER_EMAIL=mr.mustafa.ozhan@gmail.com
+POM_SCM_URL=https://github.com/SubMob/ScopeMob
+POM_SCM_CONNECTION=scm:git:git://github.com/SubMob/ScopeMob.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/SubMob/ScopeMob.git
+# Publish to the new Central Portal and auto-release (no manual "release" step)
+SONATYPE_HOST=CENTRAL_PORTAL
+SONATYPE_AUTOMATIC_RELEASE=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 
 kotlin = "2.4.0"
 kover = "0.9.8"
+mavenPublish = "0.37.0"
 
 [libraries]
 # COMMON
@@ -11,3 +12,4 @@ common-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }

--- a/scopemob/scopemob.gradle.kts
+++ b/scopemob/scopemob.gradle.kts
@@ -4,8 +4,7 @@
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
-    `maven-publish`
-    signing
+    alias(libs.plugins.mavenPublish)
 }
 
 kotlin {
@@ -20,4 +19,10 @@ kotlin {
             implementation(test)
         }
     }
+}
+
+mavenPublishing {
+    // Coordinates (GROUP + POM_ARTIFACT_ID), POM, host and auto-release come from gradle.properties.
+    // Central Portal requires signed artifacts; keys are provided in CI via ORG_GRADLE_PROJECT_* env.
+    signAllPublications()
 }


### PR DESCRIPTION
The retired OSSRH endpoint (`s01.oss.sonatype.org`, shut down June 2025) is replaced with the Sonatype Central Portal via the `com.vanniktech.maven.publish` plugin, with automatic release.

- `develop` → publishes a stable `X.Y-SNAPSHOT` (a moving "latest dev" that consumers can pin)
- `master` → auto-releases the permanent `X.Y.<commit-count>` to Maven Central (no manual release step)

Credentials + signing move to `ORG_GRADLE_PROJECT_*` env, and the hand-rolled `maven-publish`/signing configuration is removed.


Resolves SubMob/ScopeMob#267
